### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "name": "AelithBlanchett",
     "email": "tonyteur@yahoo.fr"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AelithBlanchett/fchatlib.git"
+  },
   "dependencies": {
     "async": "^1.5.2",
     "ws": "*",


### PR DESCRIPTION
This will make it so that people can find [the GitHub repository](https://github.com/AelithBlanchett/fchatlib/) from [the npmjs page](https://www.npmjs.com/package/fchatlib).
